### PR TITLE
Fixed and streamlined Mac Neuronvisio installation

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -32,7 +32,7 @@ If you are running a different flavour of GNU/Linux, like Fedora for example, ju
 the requirements with your package manager.
 
 Next, see the instructions on installation of NEURON with Python available at
-http://www.davison.webfactional.com/notes/installation-neuron-python/.
+http://www.davison.webfactional.com/notes/installation-neuron-python/
 
 Proceed to the `Package Install`_ .
 
@@ -74,7 +74,7 @@ After installing ipython you will probably want to put a link to it somewhere on
     ln -s /usr/local/share/ipython /usr/local/bin/ipython
     
 Next, see the instructions on installation of NEURON with Python available at
-http://www.davison.webfactional.com/notes/installation-neuron-python/ 
+http://www.davison.webfactional.com/notes/installation-neuron-python/ (again ensuring you are using the Homebrew version of python '/usr/local/bin/python') 
     
 Proceed to the `Package Install`_ .
 


### PR DESCRIPTION
Hi Michele, 

I went through the installation procedure again, this time on my own macbook pro (I almost always use my Ubuntu boot on it though in part because of the struggle installing things on Mac!), and found a few pip packages that I had missed in my instructions. I also found that you can avoid having to download sip and PyQt separately if you supply the right options to the brew vtk install, which makes the whole process quite a bit smoother.

Sorry to have missed your latest release, but I can confirm that the Mac installation procedure is pretty solid now. However, I did run into a few bugs when trying to load models from ModelDB and use the time slider, which I will email you about separately.

Cheers,

Tom
